### PR TITLE
Revert changes made to `ms` package in #8

### DIFF
--- a/macros/ms/tmac.s.sr
+++ b/macros/ms/tmac.s.sr
@@ -936,7 +936,7 @@ Computing Science Technical Report No. \\*(MN
 .fi
 .if (\\n(nl+1v)>(\\n(.p-\\n(FM) \{\
 .	if \\n(NX>1 .RC
-.	if \\n(NX<=1 .bp\}
+.	if \\n(NX<1 .bp\}
 .nr TD 0
 ..
 .de KD
@@ -984,7 +984,7 @@ Computing Science Technical Report No. \\*(MN
 .if !\\n(dn .nr WF 0
 .if \\n(FC<=1 .if \\n(XX=0 \{\
 .	if \\n(NX>1 .RC
-.	if \\n(NX<=1 'bp\}
+.	if \\n(NX<1 'bp\}
 .nr FC -1
 .if \\n(ML>0 .ne \\n(MLu
 ..


### PR DESCRIPTION
This pull-request reverts the changes made by @aksr in #8, for [reasons I raised earlier](https://github.com/n-t-roff/DWB3.3/pull/8#issuecomment-1015134431):

> This is a historic codebase, and should retain bug-for-bug compatibility with the original. Anybody using DWB3.3 in 2022 to format their documents is likely only doing so out of curiosity or research (i.e., comparing the behaviour of legacy `ms` packages with modern flavours).
>
> For this reason, **I strongly recommend reverting this change out of respect for historical integrity.**

/cc @n-t-roff